### PR TITLE
Add dependency for liblms

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -19,6 +19,12 @@ RUN groupadd -f -g ${GID} docker && ( getent passwd ${UID} || useradd -ms /bin/b
 RUN git clone --single-branch https://github.com/open-quantum-safe/liboqs.git && cd liboqs && git checkout db08f12b5a96aa6582a82aac7f65cf8a4d8b231f \
     && mkdir build && cd build && cmake -DOQS_DIST_BUILD=ON -DOQS_USE_CPUFEATURE_INSTRUCTIONS=OFF -DOQS_USE_OPENSSL=0 .. && make -j8 all && make install && cd ../.. && rm -rf liboqs
 
+RUN mkdir /opt/sources
+
+# install liblms
+RUN cd /opt/sources && git clone --single-branch https://github.com/cisco/hash-sigs.git && cd hash-sigs && git checkout b0631b8891295bf2929e68761205337b7c031726 \
+    && sed -i 's/USE_OPENSSL 1/USE_OPENSSL 0/g' sha256.h && make -j4 hss_lib_thread.a
+
 # Allow non-root to use tcpdump (will need NET_RAW and NET_ADMIN capability when running the container)
 RUN setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' /usr/bin/tcpdump
 


### PR DESCRIPTION
Usage: './configure --enable-lms=yes --with-liblms=/opt/sources/hash-sigs'

# Description

Please describe the scope of the fix or feature addition.

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
